### PR TITLE
bug: Allow XForwardedStrict to work when not behind proxy. aio-libs/a…

### DIFF
--- a/aiohttp_remotes/x_forwarded.py
+++ b/aiohttp_remotes/x_forwarded.py
@@ -91,6 +91,9 @@ class XForwardedStrict(XForwardedBase):
             headers = request.headers
 
             forwarded_for = self.get_forwarded_for(headers)
+            if not forwarded_for:
+                return await handler(request)
+
             peer_ip, *_ = request.transport.get_extra_info('peername')
             ips = [ip_address(peer_ip)] + list(reversed(forwarded_for))
             ip = remote_ip(self._trusted, ips)

--- a/tests/test_x_forwarded.py
+++ b/tests/test_x_forwarded.py
@@ -212,3 +212,16 @@ async def test_x_forwarded_strict_whitelist(aiohttp_client):
     resp = await cl.get('/',
                         headers={'X-Forwarded-For': '10.10.10.10'})
     assert resp.status == 200
+
+
+async def test_x_forwarded_strict_no_forwarding(aiohttp_client):
+    async def handler(request):
+        assert request.remote == '127.0.0.1'
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    await _setup(app, XForwardedStrict([['20.20.20.20']]))
+    cl = await aiohttp_client(app)
+    resp = await cl.get('/')
+    assert resp.status == 200


### PR DESCRIPTION
…iohttp-remotes#52

Addresses issue. 