### PR TITLE
Add XForwardedFiltered class

### DIFF
--- a/aiohttp_remotes/__init__.py
+++ b/aiohttp_remotes/__init__.py
@@ -14,7 +14,8 @@ from .basic_auth import BasicAuth
 from .cloudflare import Cloudflare
 from .forwarded import ForwardedRelaxed, ForwardedStrict
 from .secure import Secure
-from .x_forwarded import XForwardedRelaxed, XForwardedStrict
+from .x_forwarded import (XForwardedFiltered, XForwardedRelaxed,
+                          XForwardedStrict)
 
 
 async def setup(app, *tools):
@@ -26,5 +27,5 @@ __all__ = ('AllowedHosts', 'BasicAuth',
            'Cloudflare',
            'ForwardedRelaxed', 'ForwardedStrict',
            'Secure',
-           'XForwardedRelaxed', 'XForwardedStrict',
+           'XForwardedFiltered', 'XForwardedRelaxed', 'XForwardedStrict',
            'setup')

--- a/aiohttp_remotes/utils.py
+++ b/aiohttp_remotes/utils.py
@@ -10,6 +10,23 @@ MSG = ("Trusted list should be a sequence of sets "
 IP_CLASSES = (IPv4Address, IPv6Address, IPv4Network, IPv6Network)
 
 
+def parse_trusted_element(elem):
+    new_elem = []
+    for item in elem:
+        if isinstance(item, IP_CLASSES):
+            new_elem.append(item)
+            continue
+        try:
+            new_elem.append(ip_address(item))
+        except ValueError:
+            try:
+                new_elem.append(ip_network(item))
+            except ValueError:
+                raise ValueError(
+                    "{!r} is not IPv4 or IPv6 address or network".format(item))
+    return new_elem
+
+
 def parse_trusted_list(lst):
     if isinstance(lst, str) or not isinstance(lst, Sequence):
         raise TypeError(MSG)
@@ -25,20 +42,7 @@ def parse_trusted_list(lst):
                     "Ellipsis is allowed only at the end of list")
             if isinstance(elem, str) or not isinstance(elem, Container):
                 raise TypeError(MSG)
-            new_elem = []
-            for item in elem:
-                if isinstance(item, IP_CLASSES):
-                    new_elem.append(item)
-                    continue
-                try:
-                    new_elem.append(ip_address(item))
-                except ValueError:
-                    try:
-                        new_elem.append(ip_network(item))
-                    except ValueError:
-                        raise ValueError(
-                            "{!r} is not IPv4 or IPv6 address or network"
-                            .format(item))
+            new_elem = parse_trusted_element(elem)
         out.append(new_elem)
     return out
 

--- a/aiohttp_remotes/x_forwarded.py
+++ b/aiohttp_remotes/x_forwarded.py
@@ -1,10 +1,13 @@
+from collections.abc import Container
 from ipaddress import ip_address
 
 from aiohttp import hdrs, web
 
 from .abc import ABC
-from .exceptions import IncorrectProtoCount, RemoteError, TooManyHeaders
-from .utils import parse_trusted_list, remote_ip
+from .exceptions import (IncorrectProtoCount, RemoteError, TooManyHeaders,
+                         UntrustedIP)
+from .utils import (check_ip, parse_trusted_element, parse_trusted_list,
+                    remote_ip)
 
 
 class XForwardedBase(ABC):
@@ -74,6 +77,62 @@ class XForwardedRelaxed(XForwardedBase):
         except RemoteError as exc:
             exc.log(request)
             await self.raise_error(request)
+
+
+class XForwardedFiltered(XForwardedBase):
+
+    def __init__(self, trusted):
+        if isinstance(trusted, str) or not isinstance(trusted, Container):
+            raise TypeError(
+                "Trusted list should be a set of aaddresses or networks.")
+        self._trusted = parse_trusted_element(trusted)
+
+    @web.middleware
+    async def middleware(self, request, handler):
+        try:
+            overrides = {}
+            headers = request.headers
+
+            forwarded_for = list(reversed(self.get_forwarded_for(headers)))
+            if not forwarded_for:
+                return await handler(request)
+
+            index = 0
+            for ip in forwarded_for:
+                try:
+                    check_ip(self._trusted, ip)
+                    index += 1
+                    continue
+                except UntrustedIP:
+                    overrides["remote"] = str(ip)
+                    break
+
+            # If all the IP addresses are from trusted networks, take the
+            # left-most.
+            if "remote" not in overrides:
+                index = -1
+                overrides["remote"] = str(forwarded_for[-1])
+
+            # Ideally this should take the scheme corresponding to the entry
+            # in X-Forwarded-For that was chosen, but some proxies (the
+            # Kubernetes NGINX ingress, for example) only retain one element
+            # in X-Forwarded-Proto.  In that case, use what we have.
+            proto = list(reversed(self.get_forwarded_proto(headers)))
+            if proto:
+                if index >= len(proto):
+                    index = -1
+                overrides["scheme"] = proto[index]
+
+            host = self.get_forwarded_host(headers)
+            if host is not None:
+                overrides["host"] = host
+
+            request = request.clone(**overrides)
+            return await handler(request)
+
+        except RemoteError as exc:
+            exc.log(request)
+            return await self.raise_error(request)
 
 
 class XForwardedStrict(XForwardedBase):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -147,6 +147,39 @@ X-Forwarded
    The class does not perform any security check, use it with caution.
 
 
+.. class:: XForwardedFiltered(trusted)
+
+   The same as :class:`XForwardedRelaxed`, but rather than taking the
+   values from a specific position in the ``X-Forwarded-*`` HTTP headers,
+   this class takes a whiltelist of networks to treat as internal and
+   finds the first external IP in the ``X-Forwarded-*`` HTTP headers.  It
+   then modifies :attr:`~web.BaseRequest.scheme` and
+   :attr:`~web.BaseRequest.remote` to those values.
+
+   This class is useful when there may be an unknown number of internal
+   proxies in front of a service, so there is no simple choice of *num*
+   for :class:`XForwardedRelaxed`) and it isn't possible to strictly
+   define the sequence of proxies for :class:`XForwardedStrict`.
+
+   :attr:`~web.BaseRequest.host` is always set to the value of
+   ``X-Forwarded-Host``, if present, since it is not generally set to a
+   sequence of values separated by commas.
+
+   If ``X-Forwarded-Proto`` contains only a single value even though
+   ``X-Forwarded-For`` contains multiple values including trusted proxies,
+   that single value is used for :attr:`~web.BaseRequest.scheme`.  Some
+   proxies (such as the Kubernetes NGINX ingress) do not append schemes to
+   ``X-Forwarded-Proto``.
+
+   If all IPs in ``X-Forwarded-For`` are trusted, the left-most one is
+   used.
+
+   :param trusted: a set of IP addresses or networks, either IPv4 or IPv6,
+                   in a form accepted by :func:`~ipaddress.ip_address` or
+                   :func:`~ipaddress.ip_network`.
+
+
+
 .. class:: XForwardedStrict(trusted, *, white_paths=())
 
    Process ``X-Forwarded-*`` HTTP headers and modify corresponding

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,9 +25,10 @@ The full list of tools is:
   relaxed modes.
 * :class:`Secure` -- ensure that web application is handled by HTTPS
   (SSL/TLS) only, redirect plain HTTP to HTTPS automatically.
-* :class:`XForwardedRelaxed` and :class:`XForwardedStrict` -- the same
-  as ``ForwardedRelaxed`` and ``ForwardedStrict`` but process old-fashion
-  ``X-Forwarded-*`` headers instead of new standard ``Forwarded``.
+* :class:`XForwardedRelaxed`, :class:`XForwardedFiltered`, and
+  :class:`XForwardedStrict` -- the same as ``ForwardedRelaxed`` and
+  ``ForwardedStrict`` but process old-fashion ``X-Forwarded-*`` headers
+  instead of new standard ``Forwarded``.
 
 .. toctree::
    :maxdepth: 2

--- a/tests/test_x_forwarded.py
+++ b/tests/test_x_forwarded.py
@@ -1,6 +1,8 @@
+import pytest
 from aiohttp import web
 
-from aiohttp_remotes import XForwardedRelaxed, XForwardedStrict
+from aiohttp_remotes import (XForwardedFiltered, XForwardedRelaxed,
+                             XForwardedStrict)
 from aiohttp_remotes import setup as _setup
 
 
@@ -83,6 +85,132 @@ async def test_x_forwarded_relaxed_multiple_host(aiohttp_client):
     resp = await cl.get('/', headers=[('X-Forwarded-For', '10.10.10.10'),
                                       ('X-Forwarded-Proto', 'http'),
                                       ('X-Forwarded-Host', 'example.org'),
+                                      ('X-Forwarded-Host', 'example.com')])
+    assert resp.status == 400
+
+
+async def test_x_forwarded_filtered_ok(aiohttp_client):
+    async def handler(request):
+        assert request.host == 'example.com'
+        assert request.scheme == 'https'
+        assert request.secure
+        assert request.remote == '10.10.10.10'
+
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    await _setup(app, XForwardedFiltered(['11.0.0.0/8']))
+    cl = await aiohttp_client(app)
+    resp = await cl.get('/',
+                        headers={'X-Forwarded-For': '10.10.10.10, 11.11.11.11',
+                                 'X-Forwarded-Proto': 'https, http',
+                                 'X-Forwarded-Host': 'example.com'})
+    assert resp.status == 200
+
+
+def test_x_forwarded_filtered_invalid_config():
+    for invalid in ('127.0.0.1', '10.0.0.0/8', 42):
+        with pytest.raises(TypeError):
+            XForwardedFiltered(invalid)
+
+
+async def test_x_forwarded_filtered_no_forwards(aiohttp_client):
+    async def handler(request):
+        url = cl.make_url('/')
+        host = url.host + ':' + str(url.port)
+        assert request.host == host
+        assert request.scheme == 'http'
+        assert not request.secure
+        assert request.remote == '127.0.0.1'
+
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    await _setup(app, XForwardedFiltered(['127.0.0.1']))
+    cl = await aiohttp_client(app)
+    resp = await cl.get('/')
+    assert resp.status == 200
+
+
+async def test_x_forwarded_filtered_all_filtered(aiohttp_client):
+    async def handler(request):
+        assert request.host == 'example.com'
+        assert request.scheme == 'https'
+        assert request.secure
+        assert request.remote == '10.10.10.10'
+
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    await _setup(app, XForwardedFiltered({'10.0.0.0/8'}))
+    cl = await aiohttp_client(app)
+    resp = await cl.get('/',
+                        headers={'X-Forwarded-For': '10.10.10.10, 10.0.0.1',
+                                 'X-Forwarded-Proto': 'https, http',
+                                 'X-Forwarded-Host': 'example.com'})
+    assert resp.status == 200
+
+
+async def test_x_forwarded_filtered_one_proto(aiohttp_client):
+    async def handler(request):
+        assert request.host == 'example.com'
+        assert request.scheme == 'https'
+        assert request.secure
+        assert request.remote == '10.10.10.10'
+
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    await _setup(app, XForwardedFiltered({'11.11.11.11'}))
+    cl = await aiohttp_client(app)
+    resp = await cl.get('/',
+                        headers={'X-Forwarded-For': '10.10.10.10, 11.11.11.11',
+                                 'X-Forwarded-Proto': 'https',
+                                 'X-Forwarded-Host': 'example.com'})
+    assert resp.status == 200
+
+
+async def test_x_forwarded_filtered_no_proto_or_host(aiohttp_client):
+    async def handler(request):
+        url = cl.make_url('/')
+        host = url.host + ':' + str(url.port)
+        assert request.host == host
+        assert request.scheme == 'http'
+        assert not request.secure
+        assert request.remote == '10.10.10.10'
+
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    await _setup(app, XForwardedFiltered({'11.11.11.11'}))
+    cl = await aiohttp_client(app)
+    resp = await cl.get('/',
+                        headers={'X-Forwarded-For':
+                                 '10.10.10.10, 11.11.11.11'})
+    assert resp.status == 200
+
+
+async def test_x_forwarded_filtered_too_many_headers(aiohttp_client):
+    async def handler(request):
+        assert request.host == 'example.com'
+        assert request.scheme == 'https'
+        assert request.secure
+        assert request.remote == '10.10.10.10'
+
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    await _setup(app, XForwardedFiltered({'10.0.0.0/8'}))
+    cl = await aiohttp_client(app)
+    resp = await cl.get('/', headers=[('X-Forwarded-For', '10.10.10.10'),
+                                      ('X-Forwarded-Proto', 'https'),
+                                      ('X-Forwarded-Proto', 'http'),
                                       ('X-Forwarded-Host', 'example.com')])
     assert resp.status == 400
 


### PR DESCRIPTION
There are some circumstances in which the number of internal proxies
in front of a service is not fixed.  An example is an auth_request
handler for NGINX behind a Kubernetes NGINX ingress controller.  When
called as an auth_request handler, there are two layers of proxying.
When called directly, there is only one layer of proxying.  In this
situation, there is no good choice of num for XForwardedRelaxed.

XForwardedFiltered adds a trusted proxy list similar to
XForwardedStrict, but is not strict about the exact number of proxies
in front of the service.  Instead, it walks X-Forwarded-For from the
right side and drops entries that match the trusted list.  It then
sets the request attributes based on the first non-trusted IP that was
found.  If all IPs are in the trusted list, it uses the left-most
entry.

The current Kubernetes NGINX ingress controller only calculates a full
X-Forwarded-For header and provides only a single value in
X-Forwarded-Proto, so this implementation silently copes with that and
returns that single value if there are not enough entries in
X-Forwarded-Proto to find the entry corresponding to X-Forwarded-For.

Closes #153.