### PR TITLE
Handle invalid IP value for X-Forwarded-For header

### DIFF
--- a/CHANGES/311.bugfix
+++ b/CHANGES/311.bugfix
@@ -1,0 +1,1 @@
+Raise a ``HTTPBadRequest`` instead of ``ValueError`` when ``X-Forwarded-For`` header is not a valid IP.

--- a/aiohttp_remotes/x_forwarded.py
+++ b/aiohttp_remotes/x_forwarded.py
@@ -51,7 +51,9 @@ class XForwardedBase(ABC):
             try:
                 valid_ips.append(ip_address(addr))
             except ValueError:
-                raise web.HTTPBadRequest(reason=f"Invalid {hdrs.X_FORWARDED_FOR} header")
+                raise web.HTTPBadRequest(
+                    reason=f"Invalid {hdrs.X_FORWARDED_FOR} header"
+                )
         return valid_ips
 
     def get_forwarded_proto(self, headers: MultiMapping[str]) -> List[str]:

--- a/aiohttp_remotes/x_forwarded.py
+++ b/aiohttp_remotes/x_forwarded.py
@@ -45,7 +45,14 @@ class XForwardedBase(ABC):
         if len(forwarded_for) > 1:
             raise TooManyHeaders(hdrs.X_FORWARDED_FOR)
         forwarded_for = forwarded_for[0].split(",")
-        return [ip_address(addr) for addr in (a.strip() for a in forwarded_for) if addr]
+        valid_ips = []
+        for a in forwarded_for:
+            addr = a.strip()
+            try:
+                valid_ips.append(ip_address(addr))
+            except ValueError:
+                raise web.HTTPBadRequest(reason=f"Invalid {hdrs.X_FORWARDED_FOR} header")
+        return valid_ips
 
     def get_forwarded_proto(self, headers: MultiMapping[str]) -> List[str]:
         forwarded_proto: List[str] = headers.getall(hdrs.X_FORWARDED_PROTO, [])

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -146,6 +146,9 @@ X-Forwarded
 
    The class does not perform any security check, use it with caution.
 
+   .. versionchanged:: 1.2 Raises a :class:`~web.HTTPBadRequest``
+      when ``X-Forwarded-For`` is an invalid IP. Previously raised a
+      ``ValueError``.
 
 .. class:: XForwardedFiltered(trusted)
 


### PR DESCRIPTION
## What do these changes do?

An invalid value for the ``X-Forwarded-For`` header raises a ``ValueError`` and result in a 500
response. This handles the ``ValueError`` and returns a ``HTTPBadRequest`` instead.

## Are there changes in behavior for the user?

``ValueError`` is now a ``HTTPBadRequest`` error.

## Related issue number

n/a

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
