### PR TITLE
Use flit_core as build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires=["flit"]
-build-backend="flit.buildapi"
+requires = ["flit_core >=2,<4"]
+build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]
 module="aiohttp_remotes"


### PR DESCRIPTION
And specify a version range. This should make building faster, and ensure it works with Flit 3.x regardless of changes in future versions.