### PR TITLE
Fix basic auth user-pass string handling

### DIFF
--- a/aiohttp_remotes/basic_auth.py
+++ b/aiohttp_remotes/basic_auth.py
@@ -51,7 +51,7 @@ class BasicAuth(ABC):
             except (UnicodeDecodeError, UnicodeEncodeError, binascii.Error):
                 return await self.raise_error(request)
 
-            credentials = auth_decoded.split(":")
+            credentials = auth_decoded.split(":", 1)
 
             if len(credentials) != 2:
                 return await self.raise_error(request)

--- a/tests/test_basic_auth.py
+++ b/tests/test_basic_auth.py
@@ -1,18 +1,21 @@
+import pytest
+
 import aiohttp
 from aiohttp import web
 from aiohttp.pytest_plugin import AiohttpClient
 from aiohttp_remotes import BasicAuth, setup as _setup
 
 
-async def test_basic_auth_ok(aiohttp_client: AiohttpClient) -> None:
+@pytest.mark.parametrize("password", ["pass", "pass:pass:"])
+async def test_basic_auth_ok(aiohttp_client: AiohttpClient, password: str) -> None:
     async def handler(request: web.Request) -> web.Response:
         return web.Response()
 
     app = web.Application()
     app.router.add_get("/", handler)
-    await _setup(app, BasicAuth("user", "pass", "realm"))
+    await _setup(app, BasicAuth("user", password, "realm"))
     cl = await aiohttp_client(app)
-    resp = await cl.get("/", auth=aiohttp.BasicAuth("user", "pass"))
+    resp = await cl.get("/", auth=aiohttp.BasicAuth("user", password))
     assert resp.status == 200
 
 


### PR DESCRIPTION
## What do these changes do?

basic auth in aiohttp-remotes cannot properly split user-pass string and proceed authentication when the password contains colon `:`.

According to [rfc7617](https://www.rfc-editor.org/rfc/rfc7617.html#section-2): the first colon in a user-pass string separates user-id and password from one another. Correct parsing requires limiting the maxsplit to 1.

## Are there changes in behavior for the user?

Users can now set passwords that contain colons in basic auth.

## Related issue number

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
