### PR TITLE
Use constant-time compare in BasicAuth

### DIFF
--- a/aiohttp_remotes/basic_auth.py
+++ b/aiohttp_remotes/basic_auth.py
@@ -1,5 +1,6 @@
 import base64
 import binascii
+from secrets import compare_digest
 from typing import Awaitable, Callable, Iterable
 
 from typing_extensions import NoReturn
@@ -58,7 +59,9 @@ class BasicAuth(ABC):
 
             username, password = credentials
 
-            if username != self._username or password != self._password:
+            if username != self._username or not compare_digest(
+                password, self._password
+            ):
                 return await self.raise_error(request)
 
         return await handler(request)


### PR DESCRIPTION
## What do these changes do?

Using string comparison (`==`) to compare passwords may be vulnerable to timing attack under some scenario. This pr replaces it with constant-time compare (`hmac.compare_digest`) on password to reduce the risk.

## Are there changes in behavior for the user?

## Related issue number

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
